### PR TITLE
Should render user new locale message after update user locale not previous 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
-
+.idea
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/app/controllers/account_settings_controller.rb
+++ b/app/controllers/account_settings_controller.rb
@@ -44,7 +44,7 @@ class AccountSettingsController < ApplicationController
 
     def update_profile
       if @user.update(user_params)
-        redirect_to account_settings_path, notice: t(".You have successfully updated your profile")
+        redirect_to account_settings_path, notice: t(".You have successfully updated your profile", locale: set_locale)
       else
         render :show
       end

--- a/test/controllers/account_settings_controller_test.rb
+++ b/test/controllers/account_settings_controller_test.rb
@@ -45,7 +45,7 @@ class RepositorySettingsControllerTest < ActionDispatch::IntegrationTest
       description: "new #{@user.description}",
       location: "new #{@user.location}",
       url: "http://foo.com",
-      locale: "en"
+      locale: "zh-CN"
     }
 
     assert_require_user do
@@ -60,7 +60,7 @@ class RepositorySettingsControllerTest < ActionDispatch::IntegrationTest
     put account_settings_path, params: { user: account_params, _by: :profile }
     assert_redirected_to account_settings_path
     follow_redirect!
-    assert_select ".notice", text: "You have successfully updated your profile."
+    assert_select ".notice", text: "个人资料已经更新成功。"
     @user.reload
     assert_equal account_params[:name], @user.name
     assert_equal account_params[:slug], @user.slug


### PR DESCRIPTION
* User change locale success then redirect to profile page but flash notice message still previous locale.
* Ignore `.idea` dir if developer use rubymine 