### PR TITLE
Replace javascript alert method with Login Required Dialog(dialog) if 401 authorization fail

### DIFF
--- a/app/javascript/bluedoc/i18n.js.erb
+++ b/app/javascript/bluedoc/i18n.js.erb
@@ -20,6 +20,14 @@ i18n.init({
         "dialog": {
           "Cancel": "Cancel",
         },
+        "user":{
+          "loginRequiredDialog":{
+            "title": "Login Required",
+            "description": "You need to sign in or sign up before continuing.",
+            "okButtonTitle": "Login",
+            "cancelButtonTitle": "Cancel",
+          }
+        },
         "editor": {
           "Editor": {
             "New Document": "New Document",
@@ -217,6 +225,14 @@ i18n.init({
         "Search BlueDoc": "搜索 BlueDoc",
         "dialog": {
           "Cancel": "取消",
+        },
+        "user":{
+          "loginRequiredDialog":{
+            "title": "提示",
+            "description": "你需要先登录才能继续操作",
+            "okButtonTitle": "登录",
+            "cancelButtonTitle": "不了",
+          }
         },
         "editor": {
           "Editor": {

--- a/app/javascript/bluedoc/rails-ujs-extends.js
+++ b/app/javascript/bluedoc/rails-ujs-extends.js
@@ -1,29 +1,37 @@
-document.addEventListener("turbolinks:load", () => {
-  // Rails UJS disable-with
-  $("a,button[data-disable]").on("ajax:beforeSend", (event) => {
-    $el = $(event.currentTarget);
-    $el.attr("disabled", "disabled")
-  }).on("ajax:complete", (event) => {
-    $el = $(event.currentTarget);
-    $el.removeAttr("disabled");
-  }).on("ajax:error", (event) => {
-    const status = event.detail[1];
-    const xhr = event.detail[2];
+import loginRequiredDialog from 'components/modals/LoginRequiredDialog';
 
-    switch (xhr.status) {
-    case 401:
-      alert("You need to sign in or sign up before continuing.");
-      location.href = "/account/sign_in";
-      break;
-    case 403:
-      alert("Access denined, status: 403");
-      break;
-    case 422:
-      alert("Submit failed, please refresh browser and retry it.");
-      break;
-    default:
-      alert("Unknow error with remote submit, status: " + status);
-      break;
-    }
-  })
-})
+document.addEventListener('turbolinks:load', () => {
+  // Rails UJS disable-with
+  $('a,button[data-disable]')
+    .on('ajax:beforeSend', (event) => {
+      // eslint-disable-next-line no-undef
+      const $el = $(event.currentTarget);
+      // eslint-disable-next-line no-undef
+      $el.attr('disabled', 'disabled');
+    })
+    .on('ajax:complete', (event) => {
+      // eslint-disable-next-line no-undef
+      const $el = $(event.currentTarget);
+      // eslint-disable-next-line no-undef
+      $el.removeAttr('disabled');
+    })
+    .on('ajax:error', (event) => {
+      const status = event.detail[1];
+      const xhr = event.detail[2];
+
+      switch (xhr.status) {
+        case 401:
+          loginRequiredDialog();
+          break;
+        case 403:
+          alert('Access denined, status: 403');
+          break;
+        case 422:
+          alert('Submit failed, please refresh browser and retry it.');
+          break;
+        default:
+          alert(`Unknow error with remote submit, status: ${status}`);
+          break;
+      }
+    });
+});

--- a/app/javascript/components/modals/LoginRequiredDialog.jsx
+++ b/app/javascript/components/modals/LoginRequiredDialog.jsx
@@ -1,0 +1,63 @@
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+
+class LoginRequiredDialog extends React.Component {
+  state = {
+    open: true,
+  };
+
+  handleCancel = () => {
+    this.setState({
+      open: false,
+    });
+  };
+
+  handleLogin = () => {
+    window.location.href = '/account/sign_in';
+  };
+
+  t = (key) => {
+    if (key.startsWith('.')) {
+      return i18n.t(`user.loginRequiredDialog${key}`);
+    }
+    return i18n.t(key);
+  };
+
+  render() {
+    return (
+      <div>
+        <Dialog
+          open={this.state.open} onClose={this.handleClose}
+          aria-labelledby="alert-dialog-title"
+          aria-describedby="alert-dialog-description"
+        >
+          <DialogTitle id="alert-dialog-title">{this.t('.title')}</DialogTitle>
+          <DialogContent>
+            <DialogContentText id="alert-dialog-description">
+              {this.t('.description')}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleCancel} color="primary">
+              {this.t('.cancelButtonTitle')}
+            </Button>
+            <Button onClick={this.handleLogin} color="primary" autoFocus>
+              {this.t('.okButtonTitle')}
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  }
+}
+
+export default function () {
+  // eslint-disable-next-line no-case-declarations
+  const mountedDom = document.createElement('div');
+  document.body.appendChild(mountedDom);
+  ReactDOM.render(<LoginRequiredDialog/>, mountedDom);
+}


### PR DESCRIPTION
### Before
  If ajax request return 401 code, bluedoc will use alert method to show login first message. in my opinion javascript alert method not friendly.

### Now
  If ajax request return 401 code, bluedoc will use material-ui dialog to user. i think dialog is best than alert message.
![image](https://user-images.githubusercontent.com/10757551/61394917-cca07600-a8f6-11e9-81b5-cdc97acb7038.png)

